### PR TITLE
Allowed for Serendipity or P Meshes

### DIFF
--- a/src/cardiax/Lagrange/generate_mesh.py
+++ b/src/cardiax/Lagrange/generate_mesh.py
@@ -47,7 +47,6 @@ def gmsh_to_meshio(msh_file: Optional[str] = None, **kwargs) -> Mesh:
 def rectangle_mesh(Nx: int = 10, Ny: int = 10, 
                    Lx: float = 1.0, Ly: float = 1.0, 
                    ele_type: str = "quad", 
-                   degree: int = 1, 
                    msh_file: Optional[str] = None, 
                    verbose: bool = False) -> Mesh:
     """Generate a mesh for a rectangle using gmsh.
@@ -69,6 +68,8 @@ def rectangle_mesh(Nx: int = 10, Ny: int = 10,
     offset_y = 0.
     domain_x = Lx
     domain_y = Ly
+
+    _, _, _, _, degree, _ = get_elements(ele_type)
     gmsh.initialize()
     if not verbose:
         gmsh.option.setNumber("General.Terminal", 0)
@@ -76,7 +77,8 @@ def rectangle_mesh(Nx: int = 10, Ny: int = 10,
 
     # Need to figure out if quad8 or quad9, below is for quad8
     # Configure to get quad8 (serendipity) instead of quad9 (complete)
-    gmsh.option.setNumber("Mesh.SecondOrderIncomplete", 1)
+    if ele_type == "quad8":
+        gmsh.option.setNumber("Mesh.SecondOrderIncomplete", 1)
 
     # Create rectangle geometry
     p1 = gmsh.model.geo.addPoint(offset_x, offset_y, 0)
@@ -116,13 +118,11 @@ def rectangle_mesh(Nx: int = 10, Ny: int = 10,
 def box_mesh(Nx: int = 10, Ny: int = 10, Nz: int = 10, 
              Lx: float = 1.0, Ly: float = 1.0, Lz: float = 1.0, 
              ele_type: str = 'hexahedron', 
-             degree: int = 1, 
              msh_file: Optional[str] = None, 
              verbose: bool = False) -> Mesh:
     """
     Generate a structured box mesh using gmsh.geo API.
     """
-    assert ele_type != 'hexahedron20', "gmsh cannot produce hexahedron20 mesh?"
 
     _, _, _, _, degree, _ = get_elements(ele_type)
     
@@ -130,7 +130,8 @@ def box_mesh(Nx: int = 10, Ny: int = 10, Nz: int = 10,
     if not verbose:
         gmsh.option.setNumber("General.Terminal", 0)
     gmsh.option.setNumber("Mesh.MshFileVersion", 2.2)
-    gmsh.option.setNumber("Mesh.SecondOrderIncomplete", 1)
+    if ele_type == 'hexahedron20':
+        gmsh.option.setNumber("Mesh.SecondOrderIncomplete", 1)
 
     # Create 4 corner points for the base rectangle
     p1 = gmsh.model.geo.addPoint(0, 0, 0)

--- a/src/cardiax/_basis.py
+++ b/src/cardiax/_basis.py
@@ -103,6 +103,14 @@ class BasisFns:
                 'gauss_order': 2,
                 'degree': 2
             },
+            'quad9': {
+                're_order': [0, 1, 3, 2, 4, 6, 7, 5, 8],
+                'element_family': basix.ElementFamily.P,
+                'basix_ele': basix.CellType.quadrilateral,
+                'basix_face_ele': basix.CellType.interval,
+                'gauss_order': 2,
+                'degree': 2
+            },
             'triangle': {
                 're_order': [0, 1, 2],
                 'element_family': basix.ElementFamily.P,
@@ -201,7 +209,6 @@ class BasisFns:
         else:
             element = basix.create_element(element_family, basix_ele, degree)
         vals_and_grads = element.tabulate(1, quad_points)[:, :, re_order, :]
-        #print(type(quad_points))
         shape_values = vals_and_grads[0, :, :, 0]
         shape_grads_ref = onp.transpose(vals_and_grads[1:, :, :, 0], axes=(1, 2, 0))
         logger.debug(f"ele_type = {ele_type}, quad_points.shape = (num_quads, dim) = {quad_points.shape}")


### PR DESCRIPTION
Removed degree input for mesh creation, just pulls from ele_type. The ele_type can now be quad8/9 or hex20/27. You should be able to do for higher order as well, but I don't see a current need to use serendipity elements over normal P. #3 