### PR TITLE
Specify that surface kernel is pre-contracted with the normal vector

### DIFF
--- a/src/cardiax/_problem.py
+++ b/src/cardiax/_problem.py
@@ -370,7 +370,7 @@ class Problem(metaclass=MethodWrappingMeta):
             surface_map (callable): function that gives the vector to be contracted with the normal for the weak form. (d-D)
 
         Returns:
-            callable: function that computes the weak form of the surface term
+            callable: function that computes the weak form of the surface term (pre-contracted with the normal vector)
         """
 
         def surface_kernel(cell_sol: ArrayLike, 


### PR DESCRIPTION
Updated doc string to make this more clear. There is also a surface_map argument that says it is *not* pre-contracted with the normal. Is this accurate?